### PR TITLE
Add ZHA controller support

### DIFF
--- a/custom_components/smartir/controller.py
+++ b/custom_components/smartir/controller.py
@@ -15,6 +15,7 @@ XIAOMI_CONTROLLER = 'Xiaomi'
 MQTT_CONTROLLER = 'MQTT'
 LOOKIN_CONTROLLER = 'LOOKin'
 ESPHOME_CONTROLLER = 'ESPHome'
+ZHA_CONTROLLER = 'ZHA'
 
 ENC_BASE64 = 'Base64'
 ENC_HEX = 'Hex'
@@ -26,6 +27,7 @@ XIAOMI_COMMANDS_ENCODING = [ENC_PRONTO, ENC_RAW]
 MQTT_COMMANDS_ENCODING = [ENC_RAW]
 LOOKIN_COMMANDS_ENCODING = [ENC_PRONTO, ENC_RAW]
 ESPHOME_COMMANDS_ENCODING = [ENC_RAW]
+ZHA_COMMANDS_ENCODING = [ENC_RAW]
 
 
 def get_controller(hass, controller, encoding, controller_data, delay):
@@ -35,7 +37,8 @@ def get_controller(hass, controller, encoding, controller_data, delay):
         XIAOMI_CONTROLLER: XiaomiController,
         MQTT_CONTROLLER: MQTTController,
         LOOKIN_CONTROLLER: LookinController,
-        ESPHOME_CONTROLLER: ESPHomeController
+        ESPHOME_CONTROLLER: ESPHomeController,
+        ZHA_CONTROLLER: ZHAController
     }
     try:
         return controllers[controller](hass, controller, encoding, controller_data, delay)
@@ -130,6 +133,31 @@ class XiaomiController(AbstractController):
 
         await self.hass.services.async_call(
             'remote', 'send_command', service_data)
+
+
+class ZHAController(AbstractController):
+    """Controls a ZHA device."""
+
+    def check_encoding(self, encoding):
+        """Check if the encoding is supported by the controller."""
+        if encoding not in ZHA_COMMANDS_ENCODING:
+            raise Exception(
+                "The encoding is not supported by the ZHA controller.")
+
+    async def send(self, command):
+        """Send a command."""
+        service_data = {
+            'cluster_type': 'in',
+            'endpoint_id': 1,
+            'command': 2,
+            'ieee': self._controller_data,
+            'command_type': 'server',
+            'params': {'code': command},
+            'cluster_id': 57348,
+        }
+
+        await self.hass.services.async_call(
+            'zha', 'issue_zigbee_cluster_command', service_data)
 
 
 class MQTTController(AbstractController):

--- a/custom_components/smartir/manifest.json
+++ b/custom_components/smartir/manifest.json
@@ -9,7 +9,7 @@
   "version": "1.18.1",
   "updater": {
     "version": "1.18.1",
-    "releaseNotes": "-- Implements new async_track_state_change_event",
+    "releaseNotes": "-- Implements new async_track_state_change_event\n-- Adds ZHA controller support",
     "files": [
       "__init__.py",
       "climate.py",


### PR DESCRIPTION
## Summary
- add ZHA controller for SmartIR devices
- document ZHA controller support in manifest release notes

## Testing
- `python -m py_compile custom_components/smartir/controller.py`
- `python -m json.tool custom_components/smartir/manifest.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_b_6890feeb812c832694eecd188f9ecc84