### PR TITLE
Add remote platform support

### DIFF
--- a/codes/remote/1000.json
+++ b/codes/remote/1000.json
@@ -1,0 +1,12 @@
+{
+  "manufacturer": "Generic",
+  "supportedModels": ["Demo Remote"],
+  "supportedController": "Broadlink",
+  "commandsEncoding": "Base64",
+  "commands": {
+    "turn_on": "on_cmd",
+    "turn_off": "off_cmd",
+    "volume_up": "vol_up_cmd",
+    "volume_down": "vol_down_cmd"
+  }
+}

--- a/custom_components/smartir/__init__.py
+++ b/custom_components/smartir/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.typing import ConfigType
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = 'smartir'
-VERSION = '1.18.1'
+VERSION = '1.19.0'
 MANIFEST_URL = (
     "https://raw.githubusercontent.com/"
     "smartHomeHub/SmartIR/{}/"

--- a/custom_components/smartir/manifest.json
+++ b/custom_components/smartir/manifest.json
@@ -6,16 +6,17 @@
   "codeowners": ["@smartHomeHub"],
   "requirements": ["aiofiles>=0.6.0"],
   "homeassistant": "2025.5.0",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "updater": {
-    "version": "1.18.1",
-    "releaseNotes": "-- Implements new async_track_state_change_event\n-- Adds ZHA controller support",
+    "version": "1.19.0",
+    "releaseNotes": "-- Adds remote platform support",
     "files": [
       "__init__.py",
       "climate.py",
       "media_player.py",
       "fan.py",
-      "light.py",  
+      "light.py",
+      "remote.py",
       "controller.py",
       "manifest.json",
       "services.yaml"

--- a/custom_components/smartir/remote.py
+++ b/custom_components/smartir/remote.py
@@ -1,0 +1,185 @@
+import asyncio
+import aiofiles
+import json
+import logging
+import os.path
+
+import voluptuous as vol
+
+from homeassistant.components.remote import (
+    RemoteEntity,
+    PLATFORM_SCHEMA,
+    RemoteEntityFeature,
+)
+from homeassistant.const import CONF_NAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from . import COMPONENT_ABS_DIR, Helper
+from .controller import get_controller
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "SmartIR Remote"
+DEFAULT_DELAY = 0.5
+
+CONF_UNIQUE_ID = "unique_id"
+CONF_DEVICE_CODE = "device_code"
+CONF_CONTROLLER_DATA = "controller_data"
+CONF_DELAY = "delay"
+
+SUPPORT_FLAGS = (
+    RemoteEntityFeature.LEARN_COMMAND | RemoteEntityFeature.DELETE_COMMAND
+)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Required(CONF_DEVICE_CODE): cv.positive_int,
+        vol.Required(CONF_CONTROLLER_DATA): cv.string,
+        vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_float,
+    }
+)
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    """Set up the IR Remote platform."""
+    device_code = config.get(CONF_DEVICE_CODE)
+    device_files_subdir = os.path.join("codes", "remote")
+    device_files_absdir = os.path.join(COMPONENT_ABS_DIR, device_files_subdir)
+
+    if not os.path.isdir(device_files_absdir):
+        os.makedirs(device_files_absdir)
+
+    device_json_filename = str(device_code) + ".json"
+    device_json_path = os.path.join(device_files_absdir, device_json_filename)
+
+    if not os.path.exists(device_json_path):
+        _LOGGER.warning(
+            "Couldn't find the device Json file. The component will try to download it from the GitHub repo."
+        )
+        try:
+            codes_source = (
+                "https://raw.githubusercontent.com/"
+                "smartHomeHub/SmartIR/master/"
+                "codes/remote/{}.json"
+            )
+            await Helper.downloader(codes_source.format(device_code), device_json_path)
+        except Exception:
+            _LOGGER.error(
+                "There was an error while downloading the device Json file. Please check your internet connection or if the device code exists on GitHub. If the problem still exists please place the file manually in the proper directory."
+            )
+            return
+
+    try:
+        async with aiofiles.open(device_json_path, mode="r") as j:
+            content = await j.read()
+            device_data = json.loads(content)
+    except Exception:
+        _LOGGER.error("The device JSON file is invalid")
+        return
+
+    async_add_entities([
+        SmartIRRemote(
+            hass,
+            config,
+            device_data,
+        )
+    ])
+
+
+class SmartIRRemote(RemoteEntity, RestoreEntity):
+    def __init__(self, hass, config, device_data):
+        self.hass = hass
+        self._unique_id = config.get(CONF_UNIQUE_ID)
+        self._name = config.get(CONF_NAME)
+        self._device_code = config.get(CONF_DEVICE_CODE)
+        self._controller_data = config.get(CONF_CONTROLLER_DATA)
+        self._delay = config.get(CONF_DELAY)
+
+        self._manufacturer = device_data.get("manufacturer")
+        self._supported_models = device_data.get("supportedModels")
+        self._supported_controller = device_data.get("supportedController")
+        self._commands_encoding = device_data.get("commandsEncoding")
+        self._device_class = device_data.get("device_class")
+        self._commands = device_data.get("commands", {})
+
+        self._is_on = False
+        self._controller = get_controller(
+            hass,
+            self._supported_controller,
+            self._commands_encoding,
+            self._controller_data,
+            self._delay,
+        )
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def should_poll(self):
+        return False
+
+    @property
+    def supported_features(self):
+        return SUPPORT_FLAGS
+
+    @property
+    def is_on(self):
+        return self._is_on
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {("smartir", self._unique_id or self._device_code)},
+            "name": self._name,
+            "manufacturer": self._manufacturer,
+            "model": ", ".join(self._supported_models) if self._supported_models else None,
+        }
+
+    @property
+    def extra_state_attributes(self):
+        return {
+            "device_code": self._device_code,
+            "manufacturer": self._manufacturer,
+            "supported_models": self._supported_models,
+            "supported_controller": self._supported_controller,
+            "commands_encoding": self._commands_encoding,
+        }
+
+    async def async_turn_on(self, **kwargs):
+        command = self._commands.get("turn_on")
+        if command is not None:
+            await self._controller.send(command)
+        self._is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        command = self._commands.get("turn_off")
+        if command is not None:
+            await self._controller.send(command)
+        self._is_on = False
+        self.async_write_ha_state()
+
+    async def async_send_command(self, command, **kwargs):
+        if isinstance(command, str):
+            commands = [command]
+        else:
+            commands = command
+        for cmd in commands:
+            if cmd in self._commands:
+                await self._controller.send(self._commands[cmd])
+                await asyncio.sleep(self._delay)
+
+    async def async_learn_command(self, **kwargs):
+        command = kwargs.get("command")
+        command_data = kwargs.get("command_data", [])
+        if command:
+            self._commands[command] = command_data
+
+    async def async_delete_command(self, **kwargs):
+        command = kwargs.get("command")
+        if command in self._commands:
+            self._commands.pop(command)

--- a/custom_components/smartir/translations/en.json
+++ b/custom_components/smartir/translations/en.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "remote": {
+      "smartir": {
+        "name": "SmartIR Remote"
+      }
+    }
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 > Please respect this guideline to preserve the original project's identity.
 
 ## Overview
-SmartIR is a custom integration for controlling **climate devices**, **media players**, **fans** and **lights** via infrared controllers.<br>
+SmartIR is a custom integration for controlling **climate devices**, **media players**, **fans**, **lights** and **generic remotes** via infrared controllers.<br>
 SmartIR currently supports the following controllers:
 * [Broadlink](https://www.home-assistant.io/integrations/broadlink/)
 * [Xiaomi IR Remote (ChuangmiIr)](https://www.home-assistant.io/integrations/remote.xiaomi_miio/)
@@ -33,6 +33,7 @@ It should look similar to this:
 |       |-- fan.py
 |       |-- light.py
 |       |-- media_player.py
+|       |-- remote.py
 |       |-- etc...
 ```
 **(2)** Add the following to your configuration.yaml file.
@@ -65,6 +66,19 @@ Click on the links below for instructions on how to configure each platform.
 * [Media Player platform](/docs/MEDIA_PLAYER.md)
 * [Fan platform](/docs/FAN.md)
 * [Light platform](/docs/LIGHT.md)
+* [Remote platform](/docs/REMOTE.md)
+<br><br>
+
+### Example remote configuration
+```yaml
+- platform: smartir
+  name: Living Room IR Remote
+  unique_id: lr_remote
+  device_code: 1000
+```
+
+Supported services: `remote.send_command`, `remote.learn_command`, `remote.delete_command`.
+
 <br><br>
 
 ## See also

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -1,0 +1,12 @@
+# Remote platform
+
+Example configuration:
+```yaml
+- platform: smartir
+  name: Living Room IR Remote
+  unique_id: lr_remote
+  device_code: 1000
+  controller_data: remote.broadlink
+```
+
+Supported service calls include `remote.send_command`, `remote.learn_command` and `remote.delete_command`.

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,57 @@
+import types
+import pathlib
+import sys
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "custom_components"))
+from smartir.remote import SmartIRRemote
+
+
+class DummyController:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, command):
+        self.sent.append(command)
+
+
+@pytest.mark.asyncio
+async def test_send_and_power(monkeypatch):
+    hass = types.SimpleNamespace()
+    config = {
+        "name": "Test Remote",
+        "device_code": 1000,
+        "controller_data": "dummy",
+        "delay": 0,
+    }
+    device_data = {
+        "manufacturer": "Generic",
+        "supportedModels": ["Demo Remote"],
+        "supportedController": "Broadlink",
+        "commandsEncoding": "Base64",
+        "commands": {
+            "turn_on": "on_cmd",
+            "turn_off": "off_cmd",
+            "volume_up": "vol_up_cmd",
+        },
+    }
+
+    dummy = DummyController()
+    monkeypatch.setattr(
+        "smartir.remote.get_controller",
+        lambda *args, **kwargs: dummy,
+    )
+
+    entity = SmartIRRemote(hass, config, device_data)
+
+    # Avoid Home Assistant state machine requirements in tests
+    entity.async_write_ha_state = lambda: None
+
+    await entity.async_send_command(["volume_up"])
+    assert dummy.sent == ["vol_up_cmd"]
+
+    await entity.async_turn_on()
+    assert entity.is_on
+
+    await entity.async_turn_off()
+    assert not entity.is_on


### PR DESCRIPTION
## Summary
- add SmartIRRemote entity to handle generic IR remotes
- provide example remote model and docs
- bump version and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6891075260a8832688c047bca658e894